### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 Eclipse Checkstyle Plugin Update Site
 ====
+
+This is the P2 update site of the [Eclipse Checkstyle Plugin](https://github.com/checkstyle/eclipse-cs).
+Please go there for detailed [installation instructions](https://github.com/checkstyle/eclipse-cs#install).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>checkstyle/eclipse-cs @ GitHub</title>
+    <script type="text/Javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+<style type="text/css">
+body {
+  margin-top: 1.0em;
+  background-color: #E8F2FC;
+    font-family: Helvetica, Arial, FreeSans, sans-serif;
+  color: #000;
+}
+
+#container {
+  margin: 0 auto;
+  width: 65%;
+}
+
+h1 {
+  font-size: 3.1em;
+  color: #242630;
+  margin-bottom: 10px;
+}
+
+h1 .small {
+  font-size: 0.4em;
+}
+
+h1 a {
+  text-decoration: none
+}
+
+h2 {
+  font-size: 1.7em;
+  color: #242630;
+}
+
+a {
+  color:#242630;
+  -o-transition:.01s;
+  -ms-transition:.01s;
+  -moz-transition:.01s;
+  -webkit-transition:.01s;
+  transition:.01s;
+
+  /* Micro shadow in all sides */
+  text-shadow: 0 0 1px #79848F;
+  transform: scale(1.01);
+}
+
+a:hover {
+  color: #242630;
+}
+
+.footer {
+  text-align: center;
+  padding-top: 30px;
+  font-style: italic;
+}
+
+</style>
+
+</head>
+
+<body>
+  <a href="https://github.com/checkstyle/eclipse-cs">
+   <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
+  </a>
+
+  <div id="container">
+
+    <h1><a href="https://github.com/checkstyle/eclipse-cs">Checkstyle Eclipse Plugin</a></h1>
+      <p>Licence is <a href="https://www.gnu.org/licenses/lgpl-2.1.en.html">GNU LESSER GENERAL PUBLIC LICENSE Version 2.1</a>.
+      </span></p>
+
+    <h2>Update Site</h2>
+
+    <div>
+
+      This page is the main URL for the Eclipse update site.
+      Please use this URL in Eclipse to install the Eclipse Checkstyle Plugin, and do not try to load it in the browser.
+
+    </div>
+
+    <div class="footer">
+      Go to the main Eclipse Checkstyle Plugin page : <a href="https://github.com/checkstyle/eclipse-cs">https://github.com/checkstyle/eclipse-cs</a>
+    </div>
+    <br/>
+  </div>
+
+
+</body>
+</html>


### PR DESCRIPTION
If people stumble into the update site with a normal browser, they should be instructed to head over to the main repository for reading instructions.